### PR TITLE
[HOTFIX] Word change to make it sunny 🌞

### DIFF
--- a/client/src/components/Loading.jsx
+++ b/client/src/components/Loading.jsx
@@ -24,7 +24,7 @@ const Loading = () => {
       <LoadingSpinnerWrapper>
         <LoadingSpinner />
       </LoadingSpinnerWrapper>
-      <h2>Pouring in Berlin...</h2>
+      <h2>Pouring…</h2>
     </LoadingPage>
   );
 };


### PR DESCRIPTION
"Pouring in Berlin" makes it sound rainy and grey